### PR TITLE
Update README.md since URL is 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,2 @@
 # cpansa-feed
 Automatically updated CPAN Security Advisory Data Structure
-
-Available on https://hackeriet.github.io/cpansa-feed/cpansa.json


### PR DESCRIPTION
I don't know what you want to use as the URL, but the listed one is 404. I would have filed this as an issue but that isn't enabled for this repo.